### PR TITLE
Fix DB path constant and env vars

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -6,6 +6,9 @@ const bodyParser = require('body-parser');
 
 const jwt      = require('jsonwebtoken');
 const Twilio   = require('twilio');
+
+require('dotenv').config();
+const { TWILIO_SID, TWILIO_TOKEN, TWILIO_NUMBER } = process.env;
 const client   = new Twilio(TWILIO_SID, TWILIO_TOKEN);
 const JWT_SECRET = 'a-very-secret-key';  // move to env in prod
 
@@ -14,7 +17,7 @@ const app = express();
 app.use(cors());
 app.use(bodyParser.json());
 
-const dbPath = 'rides.db';
+const DB_PATH = 'rides.db';
 
 // GET /rides — always available, but mask contact for anonymous
 app.get('/rides', (req, res) => {


### PR DESCRIPTION
## Summary
- load env vars for Twilio config
- fix database path constant

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node backend/index.js` *(started and logged startup message)*

------
https://chatgpt.com/codex/tasks/task_e_68752b3d2900832a8c5d61fb7633c735