### PR TITLE
Improve API 404 handler

### DIFF
--- a/zen-home/package-lock.json
+++ b/zen-home/package-lock.json
@@ -8,6 +8,7 @@
       "name": "fusion-starter",
       "dependencies": {
         "aws-sdk": "^2.1692.0",
+        "bcryptjs": "^3.0.2",
         "express": "^4.18.2",
         "node-fetch": "^3.3.2",
         "twilio": "^5.7.3",
@@ -3907,6 +3908,15 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",

--- a/zen-home/package.json
+++ b/zen-home/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.1692.0",
+    "bcryptjs": "^3.0.2",
     "express": "^4.18.2",
     "node-fetch": "^3.3.2",
     "twilio": "^5.7.3",

--- a/zen-home/server/index.ts
+++ b/zen-home/server/index.ts
@@ -73,8 +73,9 @@ export function createServer() {
   app.delete("/api/rides/:rideId", deleteRide);
   app.get("/api/rides/check-updates", checkCSVUpdates);
 
-  // 404 handler for unknown routes
-  app.use((req, res) => {
+  // 404 handler for unknown API routes. Let non-API requests fall through so
+  // Vite can serve the SPA during development.
+  app.all("/api*", (_req, res) => {
     res.status(404).json({ error: "Route not found" });
   });
 


### PR DESCRIPTION
## Summary
- loosen pattern for API 404 middleware so `/api` and nested paths respond with JSON 404

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687686607098832aa70348498d2c1e54